### PR TITLE
Update database schema and RegistroTutorDTO fields

### DIFF
--- a/backend/PlataformaSaludMental/src/main/java/com/plataforma/model/dto/RegistroTutorDTO.java
+++ b/backend/PlataformaSaludMental/src/main/java/com/plataforma/model/dto/RegistroTutorDTO.java
@@ -55,6 +55,7 @@ public class RegistroTutorDTO {
 
 	@NotBlank(message = "Ingresa tu patentesco (padre, madre, tutor legal, etc.).")
 	private String parentesco;
+	
 	private Boolean consentimiento = false;
 
 	// Datos del consultante (menor)

--- a/backend/PlataformaSaludMental/src/main/resources/schema.sql
+++ b/backend/PlataformaSaludMental/src/main/resources/schema.sql
@@ -5,9 +5,18 @@ USE plataforma_db;
 -- ========================
 -- TUTORES
 -- ========================
+
 CREATE TABLE tutores (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    nombre_completo VARCHAR(150) NOT NULL,
+    nombre VARCHAR(100) NOT NULL,
+    apellido VARCHAR(100) NOT NULL,
+    dni VARCHAR(20) NOT NULL UNIQUE,
+    numero_tramite VARCHAR(50) NOT NULL,
+    fecha_nacimiento DATE NOT NULL,
+    pais VARCHAR(100) NOT NULL,
+    provincia VARCHAR(100) NOT NULL,
+    localidad VARCHAR(100) NOT NULL,
+    partido VARCHAR(100) NOT NULL,
     email VARCHAR(150) NOT NULL UNIQUE,
     telefono VARCHAR(30) NOT NULL,
     parentesco VARCHAR(100) NOT NULL,
@@ -16,8 +25,9 @@ CREATE TABLE tutores (
 );
 
 -- ========================
--- CONSULTANTES (pacientes)
+-- CONSULTANTES
 -- ========================
+
 CREATE TABLE consultantes (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     nombre VARCHAR(100) NOT NULL,
@@ -25,20 +35,25 @@ CREATE TABLE consultantes (
     dni VARCHAR(20) NOT NULL UNIQUE,
     numero_tramite VARCHAR(50) NOT NULL,
     fecha_nacimiento DATE NOT NULL,
+    pais VARCHAR(100) NOT NULL,
+    provincia VARCHAR(100) NOT NULL,
+    localidad VARCHAR(100) NOT NULL,
+    partido VARCHAR(100) NOT NULL,
     email VARCHAR(150) NOT NULL UNIQUE,
     telefono VARCHAR(30) NOT NULL,
     password VARCHAR(255) NOT NULL,
 
-    discapacidad ENUM('SI','NO','PREFIERO_NO_RESPONDER') NOT NULL DEFAULT 'PREFIERO_NO_RESPONDER',
-    cud ENUM('SI','NO','EN_TRAMITE','PREFIERO_NO_RESPONDER') NOT NULL DEFAULT 'PREFIERO_NO_RESPONDER',
+    discapacidad ENUM('SI','NO','PREFIERO_NO_RESPONDER') DEFAULT 'PREFIERO_NO_RESPONDER',
+    cud ENUM('SI','NO','EN_TRAMITE','PREFIERO_NO_RESPONDER') DEFAULT 'PREFIERO_NO_RESPONDER',
     numero_cud VARCHAR(50),
     archivo_cud VARCHAR(255),
 
-    obra_social ENUM('SI','NO') NOT NULL DEFAULT 'NO',
+    obra_social ENUM('SI','NO') DEFAULT 'NO',
     nombre_obra_social VARCHAR(150),
 
     verificado BOOLEAN DEFAULT FALSE,
     token_verificacion VARCHAR(255),
+    aceptar_tyc BOOLEAN DEFAULT FALSE,
     tutor_id BIGINT,
     fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 
@@ -48,6 +63,7 @@ CREATE TABLE consultantes (
 -- ========================
 -- PROFESIONALES
 -- ========================
+
 CREATE TABLE profesionales (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     nombre VARCHAR(100) NOT NULL,
@@ -57,33 +73,43 @@ CREATE TABLE profesionales (
     pais VARCHAR(100) NOT NULL,
     provincia VARCHAR(100) NOT NULL,
     localidad VARCHAR(100) NOT NULL,
-    matricula VARCHAR(50) NOT NULL UNIQUE,
+    partido VARCHAR(100) NOT NULL,
     celular VARCHAR(30) NOT NULL,
     email VARCHAR(150) NOT NULL UNIQUE,
     password VARCHAR(255) NOT NULL,
-    activo BOOLEAN NOT NULL DEFAULT 'FALSE',
-    
-    -- Datos profesionales / académicos
-    universidad VARCHAR(150) NOT NULL,
-    titulo VARCHAR(150) NOT NULL,
-    categoria VARCHAR(100) NOT NULL,
+
+	-- Datos profesionales / académicos
+    universidad VARCHAR(150),
+    matricula VARCHAR(50) UNIQUE,
+    titulo VARCHAR(150),
+    categoria VARCHAR(100),
     etiquetas VARCHAR(255),
+
+    descripcion VARCHAR(500),
+    imagen_perfil VARCHAR(255),
+
+    certificado_antecedentes VARCHAR(255),
+    documento_matricula VARCHAR(255),
 
     -- Estado de validación documental
     estado_validacion ENUM('PENDIENTE','VALIDADO','RECHAZADO') DEFAULT 'PENDIENTE',
-
+    activo BOOLEAN DEFAULT FALSE,
+    verificado BOOLEAN DEFAULT FALSE,
+    token_verificacion VARCHAR(255),
+    aceptar_tyc BOOLEAN DEFAULT FALSE,
     fecha_registro TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 -- ========================
 -- RELACIÓN CONSULTANTE ↔ PROFESIONAL
 -- ========================
+
 CREATE TABLE consultante_profesional (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     consultante_id BIGINT NOT NULL,
     profesional_id BIGINT NOT NULL,
     fecha_asignacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 
-    FOREIGN KEY (consultante_id) REFERENCES consultantes(id),
-    FOREIGN KEY (profesional_id) REFERENCES profesionales(id)
+    FOREIGN KEY (consultante_id) REFERENCES consultantes(id) ON DELETE CASCADE,
+    FOREIGN KEY (profesional_id) REFERENCES profesionales(id) ON DELETE CASCADE
 );


### PR DESCRIPTION
Expanded the tutores, consultantes, and profesionales tables in schema.sql to include additional personal and verification fields, adjusted some column constraints, and added ON DELETE CASCADE to foreign keys. Also added a blank line for formatting in RegistroTutorDTO.java.